### PR TITLE
Version 2.1 - Veeam 9.5 Update3a and VBR Server Management Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log information for Veeam Cookbook
 
+## Version 2.1
+2018-08-24
+
+Minor update to include default links for downloading Update 3a.  Also added a new resource and recipe to allow for automatic adding of a host to the Server Inventory of Veeam Backup and Replication.
+
+### Included:
+- Updated Helpers to include support for Veeam 9.5.0.1922 (Update 3a)
+- Add resource to control adding new Hosts into Veeam Inventory.
+
+### Information on new resources:
+
+* **VeeamHost** - Registers the provided server as the selected type by connecting to the Veeam Backup and Replication server via the Veeam PowerShell toolkit.  This resource will add a Veeam credential object if one does not exist and then register the server.
+
 ## Version 2.0
 2018-05-04
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note: Veeam prerequisites requires that Microsoft .NET Framework 4.5.2 be insta
   - [Server](#server)
   - [Console](#console)
   - [Proxy](#proxy)
+  - [Host](#host)
 - [Veeam Media and Licenses](#veeam-media-and-licenses)
   - [Veeam Backup and Replication ISO](#veeam-backup-and-replication-iso)
   - [Veeam Backup and Replication Update Zip files](#veeam-backup-and-replication-update-zip-files)
@@ -35,6 +36,7 @@ _Note: Veeam prerequisites requires that Microsoft .NET Framework 4.5.2 be insta
   - [Veeam_Explorer](#veeam_explorer)
   - [Veeam_Upgrade](#veeam_upgrade)
   - [Veeam_Proxy](#veeam_proxy)
+  - [Veeam_Host](#veeam_host)
 - [Usage](#usage)
   - [default](#default)
   - [catalog recipe](#catalog-recipe)
@@ -46,6 +48,7 @@ _Note: Veeam prerequisites requires that Microsoft .NET Framework 4.5.2 be insta
   - [proxy recipe](#proxy-recipe)
   - [proxy_remove recipe](#proxy_remove-recipe)
   - [upgrade recipe](#upgrade-recipe)
+  - [host_mgmt recipe](#host_mgmt-recipe)
 - [Upload to Chef Server](#upload-to-chef-server)
 - [Matchers/Helpers](#matchershelpers)
   - [Matchers](#matchers)
@@ -152,6 +155,20 @@ The installation of SQL Express requires that a temporary Scheduled Task be crea
 | `node['veeam']['proxy']['use_ip_address']` | String | Register to Veeam using the host IP and not the Hostname. | false | |
 | `node['veeam']['proxy']['register']` | String | Determines if the proxy_server recipe should initiate a Proxy registration | true | |
 
+### Host
+| Attribute | Type | Description | Default Value | Mandatory |
+| --- | --- | --- | --- | --- |
+| `node['veeam']['host']['vbr_server']` | String | DNS or IP Address of the Veeam Backup and Replication Server |  |  |
+| `node['veeam']['host']['vbr_port']` | String | Veeam Backup and Replication Server Port | 9392 | |
+| `node['veeam']['host']['vbr_username']` | String | Username with permissions to add Servers and Proxies within Veeam Backup and Replication server |  |  |
+| `node['veeam']['host']['vbr_password']` | String | Password for the user provided |  |  |
+| `node['veeam']['host']['host_username']` | String | Required when Adding a new Proxy.  Username with Access to the Proxy Server.  Will generate a new set of credentials within Veeam Backup and Replication server if none exist.|  |  |
+| `node['veeam']['host']['host_password']` | String | Required when Adding a new Proxy.  Password for the user provided.|  | |
+| `node['veeam']['host']['description']` | String | Description for the Proxy Server.  Will automatically start with "ADDED by CHEF: ".  Defaults to "ADDED by CHEF: Proxy Server" |  |  |
+| `node['veeam']['host']['server']` | String | Hostname or IP address of the Server to register. |  |  |
+| `node['veeam']['host']['type']` | String | Type of Server to add to the Veeam VBR Server.  Supported types:<ol><li>vmware</li><li>esxi</li><li>esx_legacy</li><li>hyperv</li><li>hyperv_cluster</li><li>hyperv_scvmm</li><li>smbv3_host</li><li>smbv3_cluster</li><li>windows</li><li>linux</li></ol> |  |  |
+| `node['veeam']['host']['action']` | String | Determines if the Host should be added or removed.  Supported types:<ol><li>add</li><li>remove</li></ol> | 'add' | |
+
 ## Veeam Media and Licenses
 
 ### Veeam Backup and Replication ISO
@@ -164,6 +181,7 @@ The attribute `node['veeam']['version']` is used to evaluate the ISO download pa
 | **9.5.0.711** | [VeeamBackup&Replication_9.5.0.711.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.711.iso) | af3e3f6db9cb4a711256443894e6fb56da35d48c0b2c32d051960c52c5bc2f00 |
 | **9.5.0.1038** | [VeeamBackup&Replication_9.5.0.1038.Update2.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1038.Update2.iso) | 180b142c1092c89001ba840fc97158cc9d3a37d6c7b25c93a311115b33454977 |
 | **9.5.0.1536** | [VeeamBackup&Replication_9.5.0.1536.Update3.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.iso) | 5020ef015e4d9ff7070d43cf477511a2b562d8044975552fd08f82bdcf556a43 |
+| **9.5.0.1922** | [VeeamBackup&Replication_9.5.0.1922.Update3a.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso) | 9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134 |
 
 
 ### Veeam Backup and Replication Update Zip files
@@ -174,6 +192,7 @@ The attribute `node['veeam']['build']` is used to evaluate the Zip download path
 | **Update 1** | [VeeamBackup&Replication_9.5.0.823_Update1.zip](https://download.veeam.com/VeeamBackup&Replication_9.5.0.823_Update1.zip) | c07bdfb3b90cc609d21ba94584ba19d8eaba16faa31f74ad80814ec9288df492 |
 | **Update 2** | [VeeamBackup&Replication_9.5.0.1038.Update2.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1038.Update2.zip) | d800bf5414f1bde95fba5fddbd86146c75a5a2414b967404792cc32841cb4ffb |
 | **Update 3** | [VeeamBackup&Replication_9.5.0.1536.Update3.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.zip) | 38ed6a30aa271989477684fdfe7b98895affc19df7e1272ee646bb50a059addc |
+| **Update 3a** | [VeeamBackup&Replication_9.5.0.1922.Update3a.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.zip) | f6b3fc0963b09362c535ef49691c51d368266cc91d6833c80c70342161bb7123 |
 
 ### Veeam Backup and Replication License file
 The server must be licensed to unlock the full potential of the application.  The attribute `node['veeam']['server']['evaluation']` should be configured as `false`.  To license, choose one of the below options.
@@ -545,6 +564,51 @@ veeam_proxy 'proxy01.demo.lab' do
 end
 ```
 
+### Veeam_Host
+Registers the host as a specific type to the Veeam VBR Server
+
+#### Actions:
+* `:add` - Registers the server to VBR
+* `:remove` - Unregisters the Server from VBR
+
+#### Properties:
+_NOTE: properties in bold are required_
+
+* `*hostname*` - DNS or IP Address of the server to register as the Proxy
+* `*vbr_server*` - DNS or IP Address of the Veeam Backup and Replication Server
+* `vbr_server_port` - Veeam Backup and Replication Server Port.  Default: 9392
+* `*vbr_username*` - Username with permissions to add Servers and Proxies within Veeam Backup and Replication server
+* `*vbr_password*` - Password for the user provided
+* `*host_username*` - Username with Access to the Server.  Will generate a new set of credentials within Veeam Backup and Replication server if none exist.
+* `*host_password*` - Password for the user provided
+* `*host_type*` - Type of Server to Add.  Supported types - vmware, esxi, esx_legacy, hyperv, hyperv_cluster, hyperv_scvmm, smbv3_host, smbv3_cluster, windows, and linux
+* `description` - Description for the Server.  Will automatically start with "ADDED by CHEF: ".  Defaults to "ADDED by CHEF: <host_type> Server"
+* `host_port` - Specifies the Port to use for the Host connection. default: 443
+
+
+#### Examples:
+```ruby
+# Add a new VMware Host
+veeam_host 'vc01.demo.lab' do
+  vbr_server      'veeam.demo.lab'
+  vbr_username    'demo\\veeamuser'
+  vbr_password    'mysecretpassword'
+  host_username  'demo\\administrator'
+  host_password  'myextrapassword'
+  host_type      'vmware'
+  action :add
+end
+```
+```ruby
+# Remove the Server registration
+veeam_proxy 'vc01.demo.lab' do
+  vbr_server      'veeam.demo.lab'
+  vbr_username    'demo\\veeamuser'
+  vbr_password    'mysecretpassword'
+  action :remove
+end
+```
+
 ## Usage
 ### default
 
@@ -584,6 +648,10 @@ Unregisters the Proxy Server and removes the Server registration from the Veeam 
 ### upgrade recipe
 Performs an upgrade of Veeam components to the requested Build level.  For more information, see [Veeam Upgrade Procedures and Details](#Veeam-Upgrade-Procedures-and-Details)
 
+### host_mgmt recipe
+
+Registers or Unregisters the Server provided to the Veeam Backup and Replication Server.
+
 ## Upload to Chef Server
 This cookbook should be included in each organization of your CHEF environment.  When importing, leverage Berkshelf:
 
@@ -606,6 +674,8 @@ _Note: Matchers should always be created in `libraries/matchers.rb` and used for
 * `install_veeam_explorer(resource_name)`
 * `add_veeam_proxy(resource_name)`
 * `remove_veeam_proxy(resource_name)`
+* `add_veeam_host(resource_name)`
+* `remove_veeam_host(resource_name)`
 * `install_veeam_upgrade(resource_name)`
 
 ### Veeam::Helper

--- a/attributes/host.rb
+++ b/attributes/host.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: veeam
+# Attributes:: host
+#
+# Copyright (c) 2017 Exosphere Data LLC, All Rights Reserved.
+
+default['veeam']['host']['vbr_server']    = nil
+default['veeam']['host']['vbr_port']      = 9392
+default['veeam']['host']['vbr_username']  = nil
+default['veeam']['host']['vbr_password']  = nil
+
+default['veeam']['host']['host_username'] = nil
+default['veeam']['host']['host_password'] = nil
+
+default['veeam']['host']['description']   = nil
+
+default['veeam']['host']['server']        = nil
+default['veeam']['host']['type']          = nil
+
+default['veeam']['host']['action']        = 'add'
+supported_host_actions                    = %w(add remove)
+raise ArgumentError, "Invalid value assigned to attribute (node['veeam']['host']['action']): #{node['veeam']['host']['action']}.  Valid values are #{supported_host_actions.join(',')}" unless %w(add remove).include?(node['veeam']['host']['action'])

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -62,6 +62,10 @@ module Veeam
         'package_url' => 'http://download2.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.iso',
         'package_checksum' => '5020ef015e4d9ff7070d43cf477511a2b562d8044975552fd08f82bdcf556a43'
       }
+      when '9.5.0.1922' then {
+        'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso',
+        'package_checksum' => '9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134'
+      }
       end
     end
 
@@ -88,7 +92,7 @@ module Veeam
         'update_checksum' => 'af3e3f6db9cb4a711256443894e6fb56da35d48c0b2c32d051960c52c5bc2f00'
       }
       when '9.5.0.823' then {
-        'update_url' => 'https://download.veeam.com/VeeamBackup&Replication_9.5.0.823_Update1.zip',
+        'update_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.0.823_Update1.zip',
         'update_checksum' => 'c07bdfb3b90cc609d21ba94584ba19d8eaba16faa31f74ad80814ec9288df492'
       }
       when '9.5.0.1038' then {
@@ -98,6 +102,10 @@ module Veeam
       when '9.5.0.1536' then {
         'update_url' => 'http://download2.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.zip',
         'update_checksum' => '38ed6a30aa271989477684fdfe7b98895affc19df7e1272ee646bb50a059addc'
+      }
+      when '9.5.0.1922' then {
+        'update_url' => 'http://download2.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.zip',
+        'update_checksum' => 'f6b3fc0963b09362c535ef49691c51d368266cc91d6833c80c70342161bb7123'
       }
       end
     end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -39,4 +39,12 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:veeam_proxy, :remove, resource_name)
   end
 
+  def add_veeam_host(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:veeam_host, :add, resource_name)
+  end
+
+  def remove_veeam_host(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:veeam_host, :remove, resource_name)
+  end
+
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.0'
+version '2.1.0'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'windows'

--- a/recipes/host_mgmt.rb
+++ b/recipes/host_mgmt.rb
@@ -1,0 +1,56 @@
+#
+# Cookbook:: veeam
+# Recipe:: host_mgmt
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+
+error_message = 'This recipe requires a Windows 2012 or higher host!'
+
+# If this host is not Windows, then abort
+raise ArgumentError, error_message unless node['platform'] == 'windows'
+
+# If this host is older than Windows 2012, we should abort the process for an unsupported platform
+raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'.to_f # '6.2.9200' is the numeric platform_version for Windows 2012
+
+veeam_prerequisites 'Install Veeam Prerequisites' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['version']
+  install_sql false
+  action :install
+end
+
+veeam_console 'Install Veeam Backup console' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['version']
+  accept_eula node['veeam']['console']['accept_eula']
+  install_dir node['veeam']['console']['install_dir']
+  keep_media true
+  action :install
+end
+
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media']
+  action :install
+end
+
+unless node['veeam']['host']['server'].nil?
+  veeam_host node['veeam']['host']['server'] do
+    vbr_server      node['veeam']['host']['vbr_server']
+    vbr_server_port node['veeam']['host']['vbr_port']
+    vbr_username    node['veeam']['host']['vbr_username']
+    vbr_password    node['veeam']['host']['vbr_password']
+    host_username   node['veeam']['host']['host_username']
+    host_password   node['veeam']['host']['host_password']
+    description     node['veeam']['host']['description']
+    host_type       node['veeam']['host']['type']
+    action          node['veeam']['host']['action'].to_sym
+    only_if { !node['veeam']['host']['server'].nil? }
+  end
+end

--- a/resources/host.rb
+++ b/resources/host.rb
@@ -1,0 +1,205 @@
+# Cookbook Name:: veeam
+# Resource:: host
+#
+# Author:: Jeremy Goodrum
+# Email:: chef@exospheredata.com
+#
+# Version:: 1.0.0
+# Date:: 2018-08-23
+#
+# Copyright (c) 2018 Exosphere Data LLC, All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default_action :add
+
+property :hostname, String, name_property: true, required: true
+
+# VBR Server Connection Properties
+property :vbr_server, String, required: true
+property :vbr_server_port, [Integer, String], default: 9392
+property :vbr_username, String, sensitive: true, required: true
+property :vbr_password, String, sensitive: true, required: true
+
+# Host Server Credentials
+property :host_username, String, sensitive: true
+property :host_password, String, sensitive: true
+
+property :host_type, String, equal_to: %w(vmware esxi esx_legacy hyperv hyperv_cluster hyperv_scvmm smbv3_host smbv3_cluster windows linux), required: true
+
+property :host_port, [Integer, String], default: 443
+
+property :description, [String, nil]
+
+# We need to include the windows helpers to keep things dry
+::Chef::Provider.send(:include, Windows::Helper)
+::Chef::Provider.send(:include, Veeam::Helper)
+
+action :add do
+  check_os_version(node)
+  # We will use the Windows Helper 'is_package_installed?' to see if the Console is installed.  If it is installed, then
+  # we should report no change back.  By returning 'false', Chef will report that the resource is up-to-date.
+  no_console_error = 'This resource requires that the Veeam Backup & Replication Console be installed on this host'
+  raise ArgumentError, no_console_error unless is_package_installed?('Veeam Backup & Replication Console')
+
+  return false if server_currently_registered
+
+  raise ArgumentError, 'The Host Username is a required attribute' if new_resource.host_username.nil?
+  raise ArgumentError, 'The Host Password is a required attribute' if new_resource.host_password.nil?
+
+  powershell_script 'Register Host Server' do
+    code <<-EOH
+      Add-PSSnapin VeeamPSSnapin
+      try {
+        Connect-VBRServer `
+          -Server #{new_resource.vbr_server} `
+          -User #{new_resource.vbr_username} `
+          -Password #{new_resource.vbr_password} `
+          -Port #{new_resource.vbr_server_port} `
+          -ErrorAction Stop
+
+        $VbrCredentials = (Get-VBRCredentials -Name #{new_resource.host_username})
+        if ($VbrCredentials -is [array]){
+          $VbrCredentials = $VbrCredentials[0]
+        }
+        if (!$VbrCredentials){
+          $VbrCredentials = (Add-VBRCredentials `
+            -User #{new_resource.host_username} `
+            -Password #{new_resource.host_password} `
+            -Description "ADDED BY CHEF: #{new_resource.host_type.upcase} Server Credentials" `
+            -Type Windows)
+        }
+
+        $VbrServer = Get-VBRServer -Name #{new_resource.hostname}
+        if(!$VbrServer) {
+          $arguments  = " -Name #{new_resource.hostname}"
+          $arguments += " -Port #{new_resource.host_port}"
+          $arguments += " -Description '#{new_resource.description ? "ADDED by CHEF: #{new_resource.description}" : "ADDED by CHEF: #{new_resource.host_type.upcase} Server"}'"
+          $arguments += " -Credentials $VbrCredentials"
+
+          switch("#{new_resource.host_type}"){
+            "vmware" {
+              $command = "Add-VBRvCenter"
+            }
+            "esxi" {
+              $command = "Add-VBRESXi"
+            }
+            "esx_legacy" {
+              $command = "Add-VBRESX"
+            }
+            "hyperv" {
+              $command = "Add-VBRHvHost"
+            }
+            "hyperv_cluster" {
+              $command = "Add-VBRHvCluster"
+            }
+            "hyperv_scvmm" {
+              $command = "Add-VBRHvScvmm"
+            }
+            "smbv3_host" {
+              $command = "Add-VBRSmbV3Host"
+            }
+            "smbv3_cluster" {
+              $command = "Add-VBRSmbV3Cluster"
+            }
+            "windows" {
+              $command = "Add-VBRWinServer"
+            }
+            "linux" {
+              $command = "Add-VBRLinux"
+            }
+            default {
+              throw "Unknown Host Type: #{new_resource.host_type}.  Unable to add host to Veeam Backup and Replication Server."
+            }
+          }
+
+          Invoke-Expression -Command $($command + $arguments)
+        }
+      } catch {
+        throw $_.Exception.message
+      } finally {
+        Disconnect-VBRServer
+      }
+    EOH
+    action :run
+    not_if { server_currently_registered }
+  end
+end
+
+action :remove do
+  check_os_version(node)
+  # We will use the Windows Helper 'is_package_installed?' to see if the Console is installed.  If it is installed, then
+  # we should report no change back.  By returning 'false', Chef will report that the resource is up-to-date.
+  no_console_error = 'This resource requires that the Veeam Backup & Replication Console be installed on this host'
+  raise ArgumentError, no_console_error unless is_package_installed?('Veeam Backup & Replication Console')
+
+  return false unless server_currently_registered
+
+  powershell_script 'Remove Host Server' do
+    code <<-EOH
+      Add-PSSnapin VeeamPSSnapin
+      try {
+        Connect-VBRServer `
+          -Server #{new_resource.vbr_server} `
+          -User #{new_resource.vbr_username} `
+          -Password #{new_resource.vbr_password} `
+          -Port #{new_resource.vbr_server_port} `
+          -ErrorAction Stop
+
+        $VbrServer = Get-VBRServer -Name #{new_resource.hostname}
+        if($VbrServer) {
+          Remove-VBRServer -Server #{new_resource.hostname} -Confirm:$False
+        }
+      } catch {
+        throw $_.Exception.message
+      } finally {
+        Disconnect-VBRServer
+      }
+    EOH
+    action :run
+    only_if { server_currently_registered }
+  end
+end
+
+action_class do
+  def whyrun_supported?
+    true
+  end
+
+  def server_currently_registered
+    cmd_str = <<-EOH
+      # Check if Host is registered
+      Add-PSSnapin VeeamPSSnapin
+      try {
+        Connect-VBRServer `
+          -Server #{new_resource.vbr_server} `
+          -User #{new_resource.vbr_username} `
+          -Password #{new_resource.vbr_password} `
+          -Port #{new_resource.vbr_server_port} `
+          -ErrorAction Stop
+        $VbrServer = Get-VBRServer -Name "#{new_resource.name}" -ErrorAction SilentlyContinue
+        if($VbrServer){
+          return $True
+        }
+        return $False
+      } catch {
+        throw $_.Exception.message
+      } finally {
+        Disconnect-VBRServer
+      }
+    EOH
+    output = validate_powershell_out(cmd_str)
+    return false if output == 'False'
+    true
+  end
+end

--- a/spec/unit/lwrps/veeam_proxy_add_spec.rb
+++ b/spec/unit/lwrps/veeam_proxy_add_spec.rb
@@ -21,8 +21,7 @@ describe 'veeam::proxy_server' do
   context 'Install Veeam Backup and Recovery Console' do
     platforms = {
       'windows' => {
-        'versions' => %w(2012)
-        # 'versions' => %w(2012 2012R2 2016)
+        'versions' => %w(2012 2012R2 2016)
       }
     }
     platforms.each do |platform, components|

--- a/spec/unit/recipes/host_mgmt_spec.rb
+++ b/spec/unit/recipes/host_mgmt_spec.rb
@@ -1,0 +1,90 @@
+#
+# Cookbook:: veeam
+# Spec:: host_mgmt_spec
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'veeam::host_mgmt' do
+  before do
+    mock_windows_system_framework # Windows Framework Helper from 'spec/windows_helper.rb'
+    stub_command('sc.exe query W3SVC').and_return 1
+  end
+  context 'Run recipe' do
+    platforms = {
+      'windows' => {
+        'versions' => %w(2012 2012R2 2016)
+      }
+    }
+    platforms.each do |platform, components|
+      components['versions'].each do |version|
+        context "On #{platform} #{version}" do
+          before do
+            Fauxhai.mock(platform: platform, version: version)
+            node.normal['veeam']['host']['vbr_server']   = 'veeam'
+            node.normal['veeam']['host']['vbr_username'] = 'admin'
+            node.normal['veeam']['host']['vbr_password'] = 'password'
+            node.normal['veeam']['host']['host_username'] = 'admin'
+            node.normal['veeam']['host']['host_password'] = 'password'
+            node.normal['veeam']['build'] = '9.5.0.1536'
+            node.normal['veeam']['host']['server'] = 'vc1'
+            node.normal['veeam']['host']['type']   = 'vmware'
+            node.normal['veeam']['host']['action'] = nil
+          end
+          let(:runner) do
+            ChefSpec::SoloRunner.new(platform: platform, version: version, file_cache_path: '/tmp/cache')
+          end
+          let(:node) { runner.node }
+          let(:chef_run) { runner.converge(described_recipe) }
+
+          it 'converges successfully' do
+            expect { chef_run }.not_to raise_error
+            expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')
+            expect(chef_run).to install_veeam_console('Install Veeam Backup console')
+            expect(chef_run).to install_veeam_upgrade('9.5.0.1536')
+            expect(chef_run).to add_veeam_host(node['veeam']['host']['server'])
+          end
+
+          it 'removes the Veeam Host Server' do
+            node.normal['veeam']['host']['action'] = 'remove'
+            expect { chef_run }.not_to raise_error
+            expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')
+            expect(chef_run).to install_veeam_console('Install Veeam Backup console')
+            expect(chef_run).to install_veeam_upgrade('9.5.0.1536')
+            expect(chef_run).to remove_veeam_host(node['veeam']['host']['server'])
+          end
+        end
+      end
+    end
+  end
+  context 'Does not install' do
+    platforms = {
+      'windows' => {
+        'versions' => %w(2008R2) # Unable to test plain Win2008 since Fauxhai doesn't have a template for 2008
+      },
+      'ubuntu' => {
+        'versions' => %w(16.04)
+      }
+    }
+    platforms.each do |platform, components|
+      components['versions'].each do |version|
+        context "On #{platform} #{version}" do
+          before do
+            Fauxhai.mock(platform: platform, version: version)
+          end
+
+          let(:chef_run) do
+            ChefSpec::SoloRunner.new(platform: platform, version: version).converge(described_recipe)
+          end
+          it 'raises an exception' do
+            expect { chef_run }.to raise_error(ArgumentError, 'This recipe requires a Windows 2012 or higher host!')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- UPDATE:  Helper Library to include download links for Veeam Update 3a
- UPDATE:  README documentation
- ADD:        Resource::Host to handle adding hosts and removing to the VBR Server
- ADD:        Recipe::HostMgmt to support adding hosts to VBR Server
- UPDATE:  Readme
- UPDATE:  Libraries::Matchers to include VeeamHost
- UPDATE:  Changelog
- BUMP:      Metadata to v2.1.0