### PR TITLE
Version 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.kitchen.local.*.yml
 
 .delivery/cli.toml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ driver:
 provisioner:
   name: chef_zero
   data_bags_path: "../../data_bags/"
-  # You many wish to test your CHEF::Log.<level> messages while using test-kitche.  Change the below
+  # You many wish to test your CHEF::Log.<level> messages while using test-kitchen.  Change the below
   # value to the level of choice.  For cleaner output, comment this option out.
   log_level: info
   # You may wish to disable always updating cookbooks in CI or other testing environments.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The attribute `node['veeam']['version']` is used to evaluate the ISO download pa
 | **9.5.0.1038** | [VeeamBackup&Replication_9.5.0.1038.Update2.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1038.Update2.iso) | 180b142c1092c89001ba840fc97158cc9d3a37d6c7b25c93a311115b33454977 |
 | **9.5.0.1536** | [VeeamBackup&Replication_9.5.0.1536.Update3.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.iso) | 5020ef015e4d9ff7070d43cf477511a2b562d8044975552fd08f82bdcf556a43 |
 | **9.5.0.1922** | [VeeamBackup&Replication_9.5.0.1922.Update3a.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso) | 9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134 |
+| **9.5.4.2615** | [VeeamBackup&Replication_9.5.4.2615.Update4.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso) | 8a594cec74059f9929ea765ac5e70a49da6fc93803b567cbb9d74fbb1a49a6cc |
 
 
 ### Veeam Backup and Replication Update Zip files
@@ -193,6 +194,7 @@ The attribute `node['veeam']['build']` is used to evaluate the Zip download path
 | **Update 2** | [VeeamBackup&Replication_9.5.0.1038.Update2.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1038.Update2.zip) | d800bf5414f1bde95fba5fddbd86146c75a5a2414b967404792cc32841cb4ffb |
 | **Update 3** | [VeeamBackup&Replication_9.5.0.1536.Update3.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.zip) | 38ed6a30aa271989477684fdfe7b98895affc19df7e1272ee646bb50a059addc |
 | **Update 3a** | [VeeamBackup&Replication_9.5.0.1922.Update3a.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.zip) | f6b3fc0963b09362c535ef49691c51d368266cc91d6833c80c70342161bb7123 |
+| **Update 4** | [VeeamBackup&Replication_9.5.4.2615.Update4.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso) | 8a594cec74059f9929ea765ac5e70a49da6fc93803b567cbb9d74fbb1a49a6cc |
 
 ### Veeam Backup and Replication License file
 The server must be licensed to unlock the full potential of the application.  The attribute `node['veeam']['server']['evaluation']` should be configured as `false`.  To license, choose one of the below options.
@@ -209,6 +211,8 @@ The server must be licensed to unlock the full potential of the application.  Th
 ## Veeam Upgrade Procedures and Details
 The process to perform upgrades requires that the appropriate installation media is provided which contains the updates from Veeam.  This cookbook will initiate an upgrade if the currently installed versions are less than the desired Build version as defined by the attribute `node['veeam']['build']`.  When the installed version does not match the requested build version, the process will mount the ISO or extract the ZIP that contains the update and then perform an automatic upgrade of each service installed on the host.
 
+> As of Update 4, the upgrade process has changed.  The update to version 9.5.4+ will be automatically applied if the installer media leverages Update4.  Due to the nature of the process, a reboot is required.  The Automatic Reboot will occur at the end of the convergance unless the attribute `nde['veeam']['reboot_on_upgrade']` equals false
+
 ### Configuring the Updates
 Updates are identified by passing one of the following to the attributes for the server:
 1. `node['veeam']['installer']['update_url']` attribute should contain either the full installation ISO or the update ZIP link.  The file name must include the full build name like such:
@@ -221,6 +225,8 @@ Updates are identified by passing one of the following to the attributes for the
     - 9.5.0.711 (GA)
     - 9.5.0.1038 (Update2)
     - 9.5.0.1536 (Update3)
+    - 9.5.0.1922 (Update3a)
+    - 9.5.4.2615 (Update4)
 
 ### Upgrade Process and Warnings
 *Warning*
@@ -231,7 +237,13 @@ If the automatic upgrade should be skipped then set the following attribute on t
 - `node['veeam']['reboot_on_upgrade']` = false
 
 ### Recipes that perform automatic upgrades
+> As of Update 4, the upgrade process has changed.  The update to version 9.5.4+ will be automatically applied if the installer media leverages Update4.  Due to the nature of the process, a reboot is required.  The Automatic Reboot will occur at the end of the convergance unless the attribute `nde['veeam']['reboot_on_upgrade']` equals false
+
 Ongoing updates are automatically handled by the following included recipes:
+- catalog
+- console
+- server_with_catalog
+- server_with_console
 - standalone_complete
 - proxy_server
 - host_mgmt

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.1'
+version '3.0.0'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'windows'

--- a/recipes/catalog.rb
+++ b/recipes/catalog.rb
@@ -15,7 +15,7 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql false
   action :install
 end
@@ -23,12 +23,20 @@ end
 veeam_catalog 'Install Veeam Backup Catalog' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_dir node['veeam']['catalog']['install_dir']
   vm_catalogpath node['veeam']['catalog']['vm_catalogpath']
   vbrc_service_user node['veeam']['catalog']['vbrc_service_user']
   vbrc_service_password node['veeam']['catalog']['vbrc_service_password']
   vbrc_service_port node['veeam']['catalog']['vbrc_service_port']
   keep_media node['veeam']['catalog']['keep_media']
+  action :install
+end
+
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media']
+  auto_reboot node['veeam']['reboot_on_upgrade']
   action :install
 end

--- a/recipes/console.rb
+++ b/recipes/console.rb
@@ -22,9 +22,17 @@ end
 veeam_console 'Install Veeam Backup console' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['console']['accept_eula']
   install_dir node['veeam']['console']['install_dir']
   keep_media node['veeam']['console']['keep_media']
+  action :install
+end
+
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media']
+  auto_reboot node['veeam']['reboot_on_upgrade']
   action :install
 end

--- a/recipes/host_mgmt.rb
+++ b/recipes/host_mgmt.rb
@@ -18,7 +18,7 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql false
   action :install
 end
@@ -26,7 +26,7 @@ end
 veeam_console 'Install Veeam Backup console' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['console']['accept_eula']
   install_dir node['veeam']['console']['install_dir']
   keep_media true

--- a/recipes/prerequisites.rb
+++ b/recipes/prerequisites.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: veeam
+# Recipe:: prerequisites
+#
+# Copyright (c) 2017 Exosphere Data LLC, All Rights Reserved.
+
+error_message = 'This recipe requires a Windows 2012 or higher host!'
+
+# If this host is not Windows, then abort
+raise ArgumentError, error_message unless node['platform'] == 'windows'
+
+# If this host is older than Windows 2012, we should abort the process for an unsupported platform
+raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'.to_f # '6.2.9200' is the numeric platform_version for Windows 2012
+
+veeam_prerequisites 'Install Veeam Prerequisites' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['build']
+  install_sql true
+  action :install
+end

--- a/recipes/proxy_server.rb
+++ b/recipes/proxy_server.rb
@@ -25,7 +25,7 @@ end
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql false
   action :install
 end
@@ -33,7 +33,7 @@ end
 veeam_console 'Install Veeam Backup console' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['console']['accept_eula']
   install_dir node['veeam']['console']['install_dir']
   keep_media true

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,7 +15,7 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql true
   action :install
 end
@@ -23,7 +23,7 @@ end
 veeam_server 'Install Veeam Backup Server' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
@@ -31,5 +31,13 @@ veeam_server 'Install Veeam Backup Server' do
   vbr_service_password node['veeam']['server']['vbr_service_password']
   vbr_service_port node['veeam']['server']['vbr_service_port']
   keep_media node['veeam']['server']['keep_media']
+  action :install
+end
+
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media']
+  auto_reboot node['veeam']['reboot_on_upgrade']
   action :install
 end

--- a/recipes/server_with_catalog.rb
+++ b/recipes/server_with_catalog.rb
@@ -15,15 +15,29 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql true
+  action :install
+end
+
+veeam_server 'Install Veeam Backup Server' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['build']
+  accept_eula node['veeam']['server']['accept_eula']
+  evaluation node['veeam']['server']['evaluation']
+  install_dir node['veeam']['server']['install_dir']
+  vbr_service_user node['veeam']['server']['vbr_service_user']
+  vbr_service_password node['veeam']['server']['vbr_service_password']
+  vbr_service_port node['veeam']['server']['vbr_service_port']
+  keep_media node['veeam']['catalog']['keep_media'] || node['veeam']['server']['keep_media']
   action :install
 end
 
 veeam_catalog 'Install Veeam Backup Catalog' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_dir node['veeam']['catalog']['install_dir']
   vm_catalogpath node['veeam']['catalog']['vm_catalogpath']
   vbrc_service_user node['veeam']['catalog']['vbrc_service_user']
@@ -33,16 +47,10 @@ veeam_catalog 'Install Veeam Backup Catalog' do
   action :install
 end
 
-veeam_server 'Install Veeam Backup Server' do
-  package_url node['veeam']['installer']['package_url']
-  package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
-  accept_eula node['veeam']['server']['accept_eula']
-  evaluation node['veeam']['server']['evaluation']
-  install_dir node['veeam']['server']['install_dir']
-  vbr_service_user node['veeam']['server']['vbr_service_user']
-  vbr_service_password node['veeam']['server']['vbr_service_password']
-  vbr_service_port node['veeam']['server']['vbr_service_port']
-  keep_media node['veeam']['catalog']['keep_media'] || node['veeam']['server']['keep_media']
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media'] || node['veeam']['console']['keep_media'] || node['veeam']['server']['keep_media']
+  auto_reboot node['veeam']['reboot_on_upgrade']
   action :install
 end

--- a/recipes/server_with_console.rb
+++ b/recipes/server_with_console.rb
@@ -15,25 +15,15 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql true
-  action :install
-end
-
-veeam_console 'Install Veeam Backup Console' do
-  package_url node['veeam']['installer']['package_url']
-  package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
-  accept_eula node['veeam']['console']['accept_eula']
-  install_dir node['veeam']['console']['install_dir']
-  keep_media true
   action :install
 end
 
 veeam_server 'Install Veeam Backup Server' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
@@ -44,11 +34,29 @@ veeam_server 'Install Veeam Backup Server' do
   action :install
 end
 
+veeam_console 'Install Veeam Backup Console' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['build']
+  accept_eula node['veeam']['console']['accept_eula']
+  install_dir node['veeam']['console']['install_dir']
+  keep_media true
+  action :install
+end
+
 veeam_explorer 'Install Veeam Backup Explorers' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   explorers node['veeam']['server']['explorers']
-  keep_media node['veeam']['console']['keep_media'] || node['veeam']['server']['keep_media']
+  keep_media true
+  action :install
+end
+
+veeam_upgrade node['veeam']['build'] do
+  package_url node['veeam']['installer']['update_url']
+  package_checksum node['veeam']['installer']['update_checksum']
+  keep_media node['veeam']['upgrade']['keep_media'] || node['veeam']['console']['keep_media'] || node['veeam']['server']['keep_media']
+  auto_reboot node['veeam']['reboot_on_upgrade']
   action :install
 end

--- a/recipes/standalone_complete.rb
+++ b/recipes/standalone_complete.rb
@@ -15,15 +15,30 @@ raise ArgumentError, error_message if node['platform_version'].to_f < '6.2.9200'
 veeam_prerequisites 'Install Veeam Prerequisites' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_sql true
+  action :install
+end
+
+veeam_server 'Install Veeam Backup Server' do
+  package_url node['veeam']['installer']['package_url']
+  package_checksum node['veeam']['installer']['package_checksum']
+  version node['veeam']['build']
+  accept_eula node['veeam']['server']['accept_eula']
+  evaluation node['veeam']['server']['evaluation']
+  install_dir node['veeam']['server']['install_dir']
+  vbr_service_user node['veeam']['server']['vbr_service_user']
+  vbr_service_password node['veeam']['server']['vbr_service_password']
+  vbr_service_port node['veeam']['server']['vbr_service_port']
+  vbr_check_updates true
+  keep_media true
   action :install
 end
 
 veeam_catalog 'Install Veeam Backup Catalog' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   install_dir node['veeam']['catalog']['install_dir']
   vm_catalogpath node['veeam']['catalog']['vm_catalogpath']
   vbrc_service_user node['veeam']['catalog']['vbrc_service_user']
@@ -36,32 +51,17 @@ end
 veeam_console 'Install Veeam Backup Console' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   accept_eula node['veeam']['console']['accept_eula']
   install_dir node['veeam']['console']['install_dir']
   keep_media node['veeam']['catalog']['keep_media'] || node['veeam']['console']['keep_media'] || node['veeam']['server']['keep_media']
   action :install
 end
 
-veeam_server 'Install Veeam Backup Server' do
-  package_url node['veeam']['installer']['package_url']
-  package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
-  accept_eula node['veeam']['server']['accept_eula']
-  evaluation node['veeam']['server']['evaluation']
-  install_dir node['veeam']['server']['install_dir']
-  vbr_service_user node['veeam']['server']['vbr_service_user']
-  vbr_service_password node['veeam']['server']['vbr_service_password']
-  vbr_service_port node['veeam']['server']['vbr_service_port']
-  vbr_check_updates true
-  keep_media true
-  action :install
-end
-
 veeam_explorer 'Install Veeam Backup Explorers' do
   package_url node['veeam']['installer']['package_url']
   package_checksum node['veeam']['installer']['package_checksum']
-  version node['veeam']['version']
+  version node['veeam']['build']
   explorers node['veeam']['server']['explorers']
   keep_media node['veeam']['console']['keep_media'] || node['veeam']['server']['keep_media']
   action :install

--- a/resources/upgrade.rb
+++ b/resources/upgrade.rb
@@ -63,7 +63,7 @@ action :install do
   # => We need to determine the actual build of installed Veeam Software.  Since there are three main packages
   # => we will need to iterate through their possible locations.
   current_build = nil
-  ['Veeam Backup & Replication Console', 'Veeam Backup & Replication Server', 'Veeam Backup & Replication Catalog'].each do |package|
+  ['Veeam Backup & Replication Console', 'Veeam Backup & Replication Server', 'Veeam Backup Catalog'].each do |package|
     current_build = find_current_veeam_version(package)
     break unless current_build.nil?
   end
@@ -79,7 +79,7 @@ action :install do
     # We need to verify that .NET Framework 4.5.2 or higher has been installed on the machine
     raise 'The Veeam Backup and Replication Server requires that Microsoft .NET Framework 4.5.2 or higher be installed.  Please install the Veeam pre-requisites' if find_current_dotnet < 379893
 
-    package_save_dir = win_friendly_path(::File.join(::Chef::Config[:file_cache_path], 'package'))
+    package_save_dir = win_clean_path(::File.join(::Chef::Config[:file_cache_path], 'package'))
 
     # This will only create the directory if it does not exist which is likely the case if we have
     # never performed a remote_file install.
@@ -97,7 +97,7 @@ action :install do
       package_name = package_name.gsub(special_char, '_')
     end
     package_type = ::File.extname(package_name)
-    installer_file_name = win_friendly_path(::File.join(package_save_dir, package_name))
+    installer_file_name = win_clean_path(::File.join(package_save_dir, package_name))
 
     install_media_path = if package_type == '.iso'
                            iso_installer(installer_file_name, new_resource)

--- a/spec/unit/lwrps/veeam_catalog_spec.rb
+++ b/spec/unit/lwrps/veeam_catalog_spec.rb
@@ -34,8 +34,8 @@ describe 'veeam::catalog' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')

--- a/spec/unit/lwrps/veeam_console_spec.rb
+++ b/spec/unit/lwrps/veeam_console_spec.rb
@@ -35,8 +35,8 @@ describe 'veeam::console' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')

--- a/spec/unit/lwrps/veeam_explorer_spec.rb
+++ b/spec/unit/lwrps/veeam_explorer_spec.rb
@@ -46,8 +46,8 @@ describe 'veeam::server_with_console' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect { chef_run }.not_to raise_error
@@ -62,7 +62,6 @@ describe 'veeam::server_with_console' do
             expect(chef_run).to create_remote_file(downloaded_file_name)
             expect(chef_run).to run_powershell_script('Load Veeam media')
             expect(chef_run).to run_ruby_block('Install Veeam Explorers')
-            expect(chef_run).to delete_file(downloaded_file_name)
           end
           it 'should RAISE an error if Veeam Server not installed' do
             allow_any_instance_of(Chef::Provider).to receive(:is_package_installed?).with('Veeam Backup & Replication Server').and_return(false)

--- a/spec/unit/lwrps/veeam_prerequisites_spec.rb
+++ b/spec/unit/lwrps/veeam_prerequisites_spec.rb
@@ -30,8 +30,8 @@ describe 'veeam::server' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')
@@ -44,11 +44,11 @@ describe 'veeam::server' do
             expect(chef_run).to run_powershell_script('Load Veeam media')
             expect(chef_run).to run_ruby_block('Install the .NET 4.5.2')
             expect(chef_run).to run_ruby_block('Install the SQL Management Tools')
-            expect(chef_run).to create_template(win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')))
+            expect(chef_run).to create_template(win_clean_path(::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')))
             expect(chef_run).to run_ruby_block('Install the SQL Express')
             expect(chef_run).to run_ruby_block('Check SQL Install State')
-            expect(chef_run).to delete_file(win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')))
-            expect(chef_run).to delete_file(win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'sql_build_script.ps1')))
+            expect(chef_run).to delete_file(win_clean_path(::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')))
+            expect(chef_run).to delete_file(win_clean_path(::File.join(Chef::Config[:file_cache_path], 'sql_build_script.ps1')))
             expect(chef_run).to delete_windows_task('Remove SQL Install Task')
 
             reboot_handler = chef_run.reboot('DotNet Install Complete')

--- a/spec/unit/lwrps/veeam_proxy_add_spec.rb
+++ b/spec/unit/lwrps/veeam_proxy_add_spec.rb
@@ -61,8 +61,8 @@ describe 'veeam::proxy_server' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect { chef_run }.not_to raise_error

--- a/spec/unit/lwrps/veeam_proxy_remove_spec.rb
+++ b/spec/unit/lwrps/veeam_proxy_remove_spec.rb
@@ -57,8 +57,8 @@ describe 'veeam::proxy_remove' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             allow(Mixlib::ShellOut).to receive(:new).with(/Check if Host is registered/, environment_var).and_return(true_shell)

--- a/spec/unit/lwrps/veeam_server_spec.rb
+++ b/spec/unit/lwrps/veeam_server_spec.rb
@@ -36,8 +36,8 @@ describe 'veeam::server' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup&Replication_9.5.0.711.iso')) }
 
           it 'converges successfully' do
             expect(chef_run).to install_veeam_prerequisites('Install Veeam Prerequisites')

--- a/spec/unit/lwrps/veeam_upgrade_spec.rb
+++ b/spec/unit/lwrps/veeam_upgrade_spec.rb
@@ -15,7 +15,7 @@ describe 'veeam::upgrade' do
   context 'Install Veeam Backup and Recovery Console' do
     platforms = {
       'windows' => {
-        'versions' => %w(2012) # 2012R2 2016)
+        'versions' => %w(2012 2012R2 2016)
       }
     }
     platforms.each do |platform, components|
@@ -38,8 +38,8 @@ describe 'veeam::upgrade' do
           end
           let(:node) { runner.node }
           let(:chef_run) { runner.converge(described_recipe) }
-          let(:package_save_dir) { win_friendly_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
-          let(:downloaded_file_name) { win_friendly_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.1536.Update3.iso')) }
+          let(:package_save_dir) { win_clean_path(::File.join(Chef::Config[:file_cache_path], 'package')) }
+          let(:downloaded_file_name) { win_clean_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.1536.Update3.iso')) }
 
           it 'converges successfully' do
             expect { chef_run }.not_to raise_error
@@ -68,8 +68,8 @@ describe 'veeam::upgrade' do
           end
           it 'should extract the media from a zip' do
             node.normal['veeam']['installer']['update_url'] = 'http://download/VeeamBackup&Replication_9.5.0.1536.Update3.zip'
-            downloaded_file_name = win_friendly_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.1536.Update3.zip'))
-            installer_path = win_friendly_path(::File.join(::Chef::Config[:file_cache_path], 'Veeam/VeeamBackup_Replication_9.5.0.1536.Update3/Updates'))
+            downloaded_file_name = win_clean_path(::File.join(package_save_dir, 'VeeamBackup_Replication_9.5.0.1536.Update3.zip'))
+            installer_path = win_clean_path(::File.join(::Chef::Config[:file_cache_path], 'Veeam/VeeamBackup_Replication_9.5.0.1536.Update3/Updates'))
             expect(chef_run).to create_remote_file(downloaded_file_name)
             expect(chef_run).to unzip_windows_zipfile(installer_path)
             expect(chef_run).to delete_file(downloaded_file_name)

--- a/spec/windows_helper.rb
+++ b/spec/windows_helper.rb
@@ -25,6 +25,7 @@
 # limitations under the License.
 # Windows Helper Method
 #
+require 'chef/util/path_helper'
 def mock_windows_system_framework
   allow_any_instance_of(Chef::Recipe)
     .to receive(:wmi_property_from_query)
@@ -43,6 +44,10 @@ def mock_windows_system_framework
   allow_any_instance_of(Chef::Provider)
     .to receive(:is_package_installed?)
     .and_return(false)
+end
+
+def win_clean_path(path)
+  Chef::Util::PathHelper.cleanpath(path)
 end
 
 def win_friendly_path(path)

--- a/templates/sql_server/sql_build_script.ps1.erb
+++ b/templates/sql_server/sql_build_script.ps1.erb
@@ -1,6 +1,13 @@
 # Install SQL Server
 
-<%= @sql_build_command %> | Out-File <%= @outputFilePath %>
+if (Test-Path -Path <%= @sql_install_media %>\SQLEXPR_x64_ENU.exe){
+    $installer_path = "<%= @sql_install_media %>\SQLEXPR_x64_ENU.exe"
+} else {
+    $installer_path = "<%= @sql_install_media %>\SqlExpress\2016SP1\SQLEXPR_x64_ENU.exe"
+}
+
+& $installer_path <%= @sql_build_command %> | Out-File <%= @outputFilePath %>
+
 
 $results = @{}
 $results.Add('output','Successfully installed SQL Server')

--- a/test/inspec/9.5.4.2399/catalog/README.md
+++ b/test/inspec/9.5.4.2399/catalog/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/test/inspec/9.5.4.2399/catalog/controls/catalog.rb
+++ b/test/inspec/9.5.4.2399/catalog/controls/catalog.rb
@@ -1,0 +1,19 @@
+control 'catalog-feature-installed' do
+  impact 1.0
+  title 'Verify Veeam Backup Catalog installed'
+  desc 'Check if the Veeam Backup Catalog instance is installed and configured'
+
+  describe port(9393) do
+    it { should be_listening }
+  end
+
+  describe service('VeeamCatalogSvc') do
+    it { should be_running }
+    its('startmode') { should match('Auto') }
+  end
+
+  describe package('Veeam Backup Catalog') do
+    it { should be_installed }
+    its('version') { should eq '9.5.4.2399' }
+  end
+end

--- a/test/inspec/9.5.4.2399/catalog/inspec.yml
+++ b/test/inspec/9.5.4.2399/catalog/inspec.yml
@@ -1,0 +1,8 @@
+name: backup_catalog
+title: Veeam Backup Catalog Server
+maintainer: 'Exosphere Data, LLC'
+copyright: 'Exosphere Data, LLC'
+copyright_email: chef@exospheredata.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile for Veeam Backup Catalog Server
+version: 0.1.0

--- a/test/inspec/9.5.4.2399/console/README.md
+++ b/test/inspec/9.5.4.2399/console/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/test/inspec/9.5.4.2399/console/controls/console.rb
+++ b/test/inspec/9.5.4.2399/console/controls/console.rb
@@ -1,0 +1,14 @@
+control 'console-feature-installed' do
+  impact 1.0
+  title 'Verify Veeam Backup and Recovery Console installed'
+  desc 'Check if the Veeam Backup and Recovery Console instance is installed and configured'
+
+  describe port(6170) do
+    it { should be_listening }
+  end
+
+  describe package('Veeam Backup & Replication Console') do
+    it { should be_installed }
+    its('version') { should eq '9.5.4.2399' }
+  end
+end

--- a/test/inspec/9.5.4.2399/console/inspec.yml
+++ b/test/inspec/9.5.4.2399/console/inspec.yml
@@ -1,0 +1,8 @@
+name: veeam_vbr_console
+title: Veeam Backup and Recovery Console
+maintainer: 'Exosphere Data, LLC'
+copyright: 'Exosphere Data, LLC'
+copyright_email: chef@exospheredata.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile for Veeam Backup and Recovery Console
+version: 0.1.0

--- a/test/inspec/9.5.4.2399/prerequisites/README.md
+++ b/test/inspec/9.5.4.2399/prerequisites/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/test/inspec/9.5.4.2399/prerequisites/controls/prerequisites.rb
+++ b/test/inspec/9.5.4.2399/prerequisites/controls/prerequisites.rb
@@ -1,0 +1,20 @@
+control 'prerequisites-feature-installed' do
+  impact 1.0
+  title 'Verify Veeam Prerequisites installed'
+  desc 'Check if the Veeam Prerequisites are installed and configured'
+
+  describe package('Microsoft System CLR Types for SQL Server 2014') do
+    it { should be_installed }
+    its('version') { should eq '12.0.2402.11' }
+  end
+
+  describe package('Microsoft SQL Server 2014 Management Objects  (x64)') do
+    it { should be_installed }
+    its('version') { should eq '12.0.2000.8' }
+  end
+
+  describe package('SQL Server 2016 Database Engine Services') do
+    it { should be_installed }
+    its('version') { should eq '13.1.4001.0' }
+  end
+end

--- a/test/inspec/9.5.4.2399/prerequisites/inspec.yml
+++ b/test/inspec/9.5.4.2399/prerequisites/inspec.yml
@@ -1,0 +1,8 @@
+name: veeam_prerequisites
+title: Veeam Prerequisites
+maintainer: 'Exosphere Data, LLC'
+copyright: 'Exosphere Data, LLC'
+copyright_email: chef@exospheredata.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile for Veeam Prerequisites
+version: 0.1.0

--- a/test/inspec/9.5.4.2399/prerequisites_nosql/README.md
+++ b/test/inspec/9.5.4.2399/prerequisites_nosql/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/test/inspec/9.5.4.2399/prerequisites_nosql/controls/prerequisites.rb
+++ b/test/inspec/9.5.4.2399/prerequisites_nosql/controls/prerequisites.rb
@@ -1,0 +1,15 @@
+control 'prerequisites-feature-installed' do
+  impact 1.0
+  title 'Verify Veeam Prerequisites installed'
+  desc 'Check if the Veeam Prerequisites are installed and configured'
+
+  describe package('Microsoft System CLR Types for SQL Server 2014') do
+    it { should be_installed }
+    its('version') { should eq '12.0.2402.11' }
+  end
+
+  describe package('Microsoft SQL Server 2014 Management Objects  (x64)') do
+    it { should be_installed }
+    its('version') { should eq '12.0.2000.8' }
+  end
+end

--- a/test/inspec/9.5.4.2399/prerequisites_nosql/inspec.yml
+++ b/test/inspec/9.5.4.2399/prerequisites_nosql/inspec.yml
@@ -1,0 +1,8 @@
+name: veeam_prerequisites
+title: Veeam Prerequisites
+maintainer: 'Exosphere Data, LLC'
+copyright: 'Exosphere Data, LLC'
+copyright_email: chef@exospheredata.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile for Veeam Prerequisites
+version: 0.1.0

--- a/test/inspec/9.5.4.2399/server/README.md
+++ b/test/inspec/9.5.4.2399/server/README.md
@@ -1,0 +1,3 @@
+# Example InSpec Profile
+
+This example shows the implementation of an InSpec [profile](../../docs/profiles.rst).

--- a/test/inspec/9.5.4.2399/server/controls/server.rb
+++ b/test/inspec/9.5.4.2399/server/controls/server.rb
@@ -1,0 +1,19 @@
+control 'Server-feature-installed' do
+  impact 1.0
+  title 'Verify Veeam Backup Server installed'
+  desc 'Check if the Veeam Backup Server instance is installed and configured'
+
+  describe port(9392) do
+    it { should be_listening }
+  end
+
+  describe service('VeeamBackupSvc') do
+    it { should be_running }
+    its('startmode') { should match('Auto') }
+  end
+
+  describe package('Veeam Backup & Replication Server') do
+    it { should be_installed }
+    its('version') { should eq '9.5.4.2399' }
+  end
+end

--- a/test/inspec/9.5.4.2399/server/inspec.yml
+++ b/test/inspec/9.5.4.2399/server/inspec.yml
@@ -1,0 +1,8 @@
+name: backup_server
+title: Veeam Backup and Recovery Server
+maintainer: 'Exosphere Data, LLC'
+copyright: 'Exosphere Data, LLC'
+copyright_email: chef@exospheredata.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile for Veeam Backup and Recovery Server
+version: 0.1.0


### PR DESCRIPTION
UPDATE: Kitchen.yml typo
UPDATE: Libraries::Helper to enhance prerequisites versions
UPDATE: Libraries::Helper to include support to ignore_errors in validate_cmd method when called from method find_current_veeam_version
UPDATE: Libraries::Helper to include version information for explorers and win_clean_path helper
UPDATE: Libraries::Helper to include links for 9.5.4

UPDATE: Recipes::Catalog to include calling veeam_upgrade by default
UPDATE: Recipes::Console to include veaam_upgrade
UPDATE: Recipes::HostMgmt to support 9.5.4
ADD:    Recipes::Prerequisites
UPDATE: Recipes::ProxyServer to support 9.5.4
UPDATE: Recipes::Server to support 9.5.4
UPDATE: Recipes::ServerWithConsole to include upgrades and build version handling
UPDATE: Recipes::StandaloneComplete to support 9.5.4

UPDATE: Resources to use win_clean_path instead of win_friendly_path from Windows Cookbook
UPDATE: Resources::Catalog to handle installation of 9.5.4 media and upgrades of the current version from 9.5.0 to 9.5.4 when version is selected
UPDATE: Resources::Console to support upgrading and installing 9.5.4
UPDATE: Resources::Explorer to support 9.5.4 version upgrades
UPDATE: Resources::Prerequisites to support new version of SQL Express installation based on the build_version
UPDATE: Resources::Server to enable support for upgrading the version to 9.5.4
UPDATE: Resources::Upgrade to initiate an upgrade when the Veeam Backup Catalog version does not match the requested build version

UPDATE: Templates::SqlBuildScript to handle installation of SQL Express 2016 when performing a new installation of 9.5 Update 4
ADD:    Test::Inspec/9.5.4

UPDATE: README
BUMP:	Metadata to Version 3.0.0