### PR TITLE
Reboot delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log information for Veeam Cookbook
 
+## Version 3.0.1
+2020-07-14
+
+Minor fix update to include `delay_min 1` to all reboot resources to cover a chef bug that lets some test-kitchen environments crash.
+
 ## Version 2.1.1
 2018-08-25
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.0'
+version '3.0.1'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'windows'

--- a/resources/prerequisites.rb
+++ b/resources/prerequisites.rb
@@ -105,6 +105,7 @@ action_class do
   def install_dotnet(downloaded_file_name)
     return 'Already installed' if find_current_dotnet >= 379893
     reboot 'DotNet Install Complete' do
+      delay_mins 1
       reason 'Reboot required after an installation of .NET Framework'
       action :nothing
     end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -216,6 +216,7 @@ action_class do
     Chef::Log.debug 'Installing Veeam Backup server service... success'
 
     reboot 'Required Reboot after Veeam Installation or Upgrade' do
+      delay_mins 1
       action :request_reboot
       only_if { reboot_pending? }
       only_if { new_resource.auto_reboot }

--- a/resources/upgrade.rb
+++ b/resources/upgrade.rb
@@ -201,6 +201,7 @@ action_class do
     end
 
     reboot 'Required Reboot after Veeam Upgrade' do
+      delay_mins 1
       action :request_reboot
       only_if { reboot_pending? }
       only_if { new_resource.auto_reboot }


### PR DESCRIPTION
Added a 1 minute reboot delay to cover a bug that exists in some chef-kitchen environments that make the chef-client crash on reboots as mentioned in the forum post below.

(See the comment of "roberto-mardeni")
https://github.com/chrisgit/test_kitchen-multiboot/issues/1

