### PR TITLE
Version 3.0.2 - Fix SQL Express installation problem for domain joined server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log information for Veeam Cookbook
 
+## Version 3.0.2
+2020-07-24
+
+Minor fix update for SQL Express installation on domain joined computer.
+
 ## Version 3.0.1
 2020-07-14
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.1'
+version '3.0.2'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'windows'

--- a/resources/prerequisites.rb
+++ b/resources/prerequisites.rb
@@ -162,6 +162,7 @@ action_class do
     sql_build_script = win_clean_path(::File.join(Chef::Config[:file_cache_path], 'sql_build_script.ps1'))
 
     sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"#{node['hostname']}\\#{ENV['USERNAME']}"
+    sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"#{ENV['USERDOMAIN']}\\#{ENV['USERNAME']}" if node['kernel']['cs_info']['part_of_domain']
     sql_sys_admin_list = node['veeam']['server']['vbr_service_user'] if node['veeam']['server']['vbr_service_user']
 
     template config_file_path do


### PR DESCRIPTION
I found that SQL Express installation fails on domain joined computer.
I believe `#{ENV['USERDOMAIN']}\\#{ENV['USERNAME']}` should be added to `sql_sys_admin_list` instead of `"#{node['hostname']}\\#{ENV['USERNAME']}"` if the computer is domain joined.

I've tested and confirmed it works on a domain joined computer and non-domain joined.
Thank you for your review.