### PR TITLE
Sql authentication mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log information for Veeam Cookbook
 
-## Version 4.0.2
+## Version 4.0.1
 2020-08-06
 
 Updated - Changed SQL authentication mode from "Mixed" to "Windows"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change log information for Veeam Cookbook
 
-## Version 4.0.1
-2020-08-06
+## Version 4.0.2
+2020-08-12
 
 Updated - Changed SQL authentication mode from "Mixed" to "Windows"
+
+## Version 4.0.1
+2020-08-6
+
+Added support for Veeam 9.5.4b
 
 ## Version 4.0.0
 2020-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log information for Veeam Cookbook
 
+## Version 4.0.2
+2020-08-06
+
+Updated - Changed SQL authentication mode from "Mixed" to "Windows"
+
 ## Version 4.0.0
 2020-07-15
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ The installation of SQL Express requires that a temporary Scheduled Task be crea
 | `node['veeam']['server']['vbr_sqlserver_password']` | String | This parameter must be used if you have specified the `VBR_SQLSERVER_AUTHENTICATION` parameter.  Specifies a password to connect to the Microsoft SQL Server in the SQL Server authentication mode. | nil | |
 | `node['veeam']['server']['pf_ad_nfsdatastore']` | String | Specifies the vPower NFS root folder to which Instant VM Recovery cache will be stored. | C:\ProgramData\Veeam\Backup\NfsDatastore\ | |
 | `node['veeam']['server']['keep_media']` | TrueFalse |  Determines if the recipe should keep the media at the end of the installation. | false | |
-| `node['sql_server']['server_sa_password']` | String | Configures the SQL Admin password for the SQLExpress instance. | 'Veeam1234' | |
 | `node['veeam']['server']['explorers']` | Array. List of Veeam Explorers to install. | 'ActiveDirectory','Exchange','SQL','Oracle','SharePoint' | |
 
 ### Console

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -23,7 +23,5 @@ default['veeam']['server']['vbr_sqlserver_password'] = nil
 default['veeam']['server']['pf_ad_nfsdatastore'] = nil
 default['veeam']['server']['keep_media'] = false
 
-default['sql_server']['server_sa_password'] = 'Veeam1234'
-
 # Install all of the explorers by default.  New explorers shoudl be included in the libraries/helper.rb file
 default['veeam']['server']['explorers'] = %w(ActiveDirectory Exchange SQL Oracle SharePoint)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.1'
+version '4.0.2'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.3'
+version '4.0.1'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.0'
+version '4.0.3'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/resources/prerequisites.rb
+++ b/resources/prerequisites.rb
@@ -168,8 +168,8 @@ action_class do
     output_file      = win_clean_path(::File.join(Chef::Config[:file_cache_path], 'sql_install.log'))
     sql_build_script = win_clean_path(::File.join(Chef::Config[:file_cache_path], 'sql_build_script.ps1'))
 
-    sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"#{node['hostname']}\\#{ENV['USERNAME']}"
-    sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"#{ENV['USERDOMAIN']}\\#{ENV['USERNAME']}" if node['kernel']['cs_info']['part_of_domain']
+    sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"BUILTIN\\Administrators\" \"#{node['hostname']}\\#{ENV['USERNAME']}"
+    sql_sys_admin_list = "NT AUTHORITY\\SYSTEM\" \"BUILTIN\\Administrators\" \"#{ENV['USERDOMAIN']}\\#{ENV['USERNAME']}" if node['kernel']['cs_info']['part_of_domain']
     sql_sys_admin_list = node['veeam']['server']['vbr_service_user'] if node['veeam']['server']['vbr_service_user']
 
     template config_file_path do

--- a/templates/sql_server/ConfigurationFile.ini.erb
+++ b/templates/sql_server/ConfigurationFile.ini.erb
@@ -8,8 +8,7 @@ IACCEPTSQLSERVERLICENSETERMS="True"
 
 ; The default is Windows Authentication. Use "SQL" for Mixed Mode Authentication.
 
-SECURITYMODE="SQL"
-SAPWD="<%= node['sql_server']['server_sa_password'] %>"
+; SECURITYMODE="SQL"
 
 ; Specify whether SQL Server Setup should discover and include product updates. The valid values are True and False or 1 and 0. By default SQL Server Setup will include updates that are found.
 


### PR DESCRIPTION
I think we can improve the cookbooks security by revisiting how we handle SQL authentication. Currently we use an attribute to set the SQL SA password and then pass it to the ConfigurationFile.ini.erb file. However, when the chef-client runs, all attributes get send back to the chef server and are stored in plain-text. Using the "knife" command anyone having access to the chef server can read all attributes from any node including the SA Password. A colleague if mine showed me this was possible with this cookbook.

This problem seems hard to solve without making significant code changes. So instead of solving it I propose we make a workaround. In the cookbook we now install SQL in "Mixed authentication mode". However this is not how SQL gets installed by Veeam natively where it uses "windows authentication mode". This means that windows accounts are granted sys-admin access instead of SA. I propose we work around the problem by switching to "windows authentication mode" since the SA account is not used by Veeam anyway.

Pros:
- No insecurely stored SA account in an attribute
- No novice users that can forget to overwrite the default SA password
- More in line with how the manual Veeam installer deploys Veeam.

I have tested this code and it worked for me.