### PR TITLE
9.5.4b support for v10 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log information for Veeam Cookbook
 
+## Version 4.0.2
+2020-08-6
+
+Added support for Veeam 9.5.4b
+
 ## Version 4.0.0
 2020-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log information for Veeam Cookbook
 
-## Version 4.0.2
+## Version 4.0.1
 2020-08-6
 
 Added support for Veeam 9.5.4b

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The attribute `node['veeam']['version']` is used to evaluate the ISO download pa
 | **9.5.0.1536** | [VeeamBackup&Replication_9.5.0.1536.Update3.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.iso) | 5020ef015e4d9ff7070d43cf477511a2b562d8044975552fd08f82bdcf556a43 |
 | **9.5.0.1922** | [VeeamBackup&Replication_9.5.0.1922.Update3a.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso) | 9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134 |
 | **9.5.4.2615** | [VeeamBackup&Replication_9.5.4.2615.Update4.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso) | 8a594cec74059f9929ea765ac5e70a49da6fc93803b567cbb9d74fbb1a49a6cc |
+| **9.5.4.2866** | [VeeamBackup&Replication_9.5.4.2866.Update4b_20191210.iso](https://download2.veeam.com/VeeamBackup&Replication_9.5.4.2866.Update4b_20191210.iso) | cfc41596154563f60b74320634589721fd1110c87e04632068bc5234aada342e |
 | **10.0** | [VeeamBackup&Replication_10.0.0.4461.iso](http://download.veeam.com/VeeamBackup&Replication_10.0.0.4461.iso) | 26ddcc3df046af1ca1458b3040fc9024b4361ae1e51e1cf4516afe53fb024650 |
 | **10.0.0.4461** | [VeeamBackup&Replication_10.0.0.4461.iso](http://download.veeam.com/VeeamBackup&Replication_10.0.0.4461.iso) | 26ddcc3df046af1ca1458b3040fc9024b4361ae1e51e1cf4516afe53fb024650 |
 
@@ -199,6 +200,7 @@ _Note: As of 9.5 Update 4, ISO based upgrades must be done using the `package_ur
 | **9.5 Update 3** | [VeeamBackup&Replication_9.5.0.1536.Update3.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.zip) | 38ed6a30aa271989477684fdfe7b98895affc19df7e1272ee646bb50a059addc |
 | **9.5 Update 3a** | [VeeamBackup&Replication_9.5.0.1922.Update3a.zip](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.zip) | f6b3fc0963b09362c535ef49691c51d368266cc91d6833c80c70342161bb7123 |
 | **9.5 Update 4** | [VeeamBackup&Replication_9.5.4.2615.Update4.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso) | 8a594cec74059f9929ea765ac5e70a49da6fc93803b567cbb9d74fbb1a49a6cc |
+
 
 
 ### Veeam Backup and Replication License file
@@ -235,6 +237,7 @@ Updates are identified by passing one of the following to the attributes for the
     - 9.5.0.1536 (Update3)
     - 9.5.0.1922 (Update3a)
     - 9.5.4.2615 (Update4)
+    - 9.5.4.2866 (Update4b)
     - 10.0 (defaults to GA)
     - 10.0.0.4461 (GA)
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -71,6 +71,10 @@ module Veeam
         'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso',
         'package_checksum' => 'ecc27bbcf49104861566782701dca42375b324b4710e2fa79b5f8068c31c4494'
       }
+      when '9.5.4.2866' then {
+        'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.4.2866.Update4b_20191210.iso',
+        'package_checksum' => 'cfc41596154563f60b74320634589721fd1110c87e04632068bc5234aada342e'
+      }
       when '10.0.0.4461' then {
         'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_10.0.0.4461.iso',
         'package_checksum' => '26ddcc3df046af1ca1458b3040fc9024b4361ae1e51e1cf4516afe53fb024650'
@@ -119,6 +123,10 @@ module Veeam
       when '9.5.4.2615' then {
         'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.4.2615.Update4.iso',
         'package_checksum' => 'ecc27bbcf49104861566782701dca42375b324b4710e2fa79b5f8068c31c4494'
+      }
+      when '9.5.4.2866' then {
+        'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_9.5.4.2866.Update4b_20191210.iso',
+        'package_checksum' => 'cfc41596154563f60b74320634589721fd1110c87e04632068bc5234aada342e'
       }
       when '10.0.0.4461' then {
         'package_url' => 'https://download2.veeam.com/VeeamBackup&Replication_10.0.0.4461.iso',

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.4'
+version '4.0.1'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.2'
+version '4.0.4'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.0'
+version '4.0.2'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/resources/catalog.rb
+++ b/resources/catalog.rb
@@ -51,7 +51,7 @@ action :install do
     installed_version = installed_packages['Veeam Backup Catalog'][:version]
 
     # => If the build version and the installed version match then return up-to-date
-    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(installed_version)
+    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(find_current_veeam_version('Veeam Backup & Replication Server'))
 
     # => Previous versions are upgraded through update files and therefore, this is up-to-date
     return false if Gem::Version.new(new_resource.version) <= Gem::Version.new('9.5.3.0')

--- a/resources/console.rb
+++ b/resources/console.rb
@@ -48,7 +48,7 @@ action :install do
     installed_version = installed_packages['Veeam Backup & Replication Console'][:version]
 
     # => If the build version and the installed version match then return up-to-date
-    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(installed_version)
+    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(find_current_veeam_version('Veeam Backup & Replication Server'))
 
     # => Previous versions are upgraded through update files and therefore, this is up-to-date
     return false if Gem::Version.new(new_resource.version) <= Gem::Version.new('9.5.3.0')

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -68,7 +68,7 @@ action :install do
     installed_version = installed_packages['Veeam Backup & Replication Server'][:version]
 
     # => If the build version and the installed version match then return up-to-date
-    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(installed_version)
+    return false if Gem::Version.new(new_resource.version) == Gem::Version.new(find_current_veeam_version('Veeam Backup & Replication Server'))
 
     # => Previous versions are upgraded through update files and therefore, this is up-to-date
     return false if Gem::Version.new(new_resource.version) <= Gem::Version.new('9.5.3.0')


### PR DESCRIPTION
Per this PR I would like to propose we add 9.5.4b support to the new v10 branch.
I have tested the code and it works for me.

Please note the change in "resources/server.rb"
This was needed because of a bug in 4b where windows returns the wrong veeam version as shown in the screenshot below.

![Capture](https://user-images.githubusercontent.com/65891040/89648706-ea54ca80-d8bf-11ea-942f-f6fdf6cc649b.PNG)


