### PR TITLE
Flexible SQL instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log information for Veeam Cookbook
 
+## Version 4.1.0
+2020-09-02
+
+- UPDATE: SQL instance names are now flexible trough an attribute.
+
 ## Version 4.0.3
 2020-08-14
 

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -14,12 +14,11 @@ default['veeam']['server']['vbr_service_password'] = nil
 default['veeam']['server']['vbr_service_port'] = nil
 default['veeam']['server']['vbr_secure_connections_port'] = nil
 # SQL Server Connection Details
-default['veeam']['server']['vbr_sqlserver_server'] = nil
+default['veeam']['server']['vbr_sqlserver_server'] = ".\\VeeamSQL2016"
 default['veeam']['server']['vbr_sqlserver_database'] = nil
 default['veeam']['server']['vbr_sqlserver_auth'] = nil
 default['veeam']['server']['vbr_sqlserver_username'] = nil
 default['veeam']['server']['vbr_sqlserver_password'] = nil
-
 default['veeam']['server']['pf_ad_nfsdatastore'] = nil
 default['veeam']['server']['keep_media'] = false
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Exosphere Data, LLC'
 maintainer_email 'chef@exospheredata.com'
 license 'Apache-2.0'
 description 'Installs/Configures Veeam Backup and Recovery'
-version '4.0.3'
+version '4.1.0'
 chef_version '>= 13.0'
 
 supports 'windows'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -30,6 +30,7 @@ veeam_server 'Install Veeam Backup Server' do
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
+  vbr_sqlserver_server node['veeam']['server']['vbr_sqlserver_server']
   vbr_service_user node['veeam']['server']['vbr_service_user']
   vbr_service_password node['veeam']['server']['vbr_service_password']
   vbr_service_port node['veeam']['server']['vbr_service_port']

--- a/recipes/server_with_catalog.rb
+++ b/recipes/server_with_catalog.rb
@@ -30,6 +30,7 @@ veeam_server 'Install Veeam Backup Server' do
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
+  vbr_sqlserver_server node['veeam']['server']['vbr_sqlserver_server']
   vbr_service_user node['veeam']['server']['vbr_service_user']
   vbr_service_password node['veeam']['server']['vbr_service_password']
   vbr_service_port node['veeam']['server']['vbr_service_port']

--- a/recipes/server_with_console.rb
+++ b/recipes/server_with_console.rb
@@ -30,6 +30,7 @@ veeam_server 'Install Veeam Backup Server' do
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
+  vbr_sqlserver_server node['veeam']['server']['vbr_sqlserver_server']
   vbr_service_user node['veeam']['server']['vbr_service_user']
   vbr_service_password node['veeam']['server']['vbr_service_password']
   vbr_service_port node['veeam']['server']['vbr_service_port']

--- a/recipes/standalone_complete.rb
+++ b/recipes/standalone_complete.rb
@@ -30,6 +30,7 @@ veeam_server 'Install Veeam Backup Server' do
   accept_eula node['veeam']['server']['accept_eula']
   evaluation node['veeam']['server']['evaluation']
   install_dir node['veeam']['server']['install_dir']
+  vbr_sqlserver_server node['veeam']['server']['vbr_sqlserver_server']
   vbr_service_user node['veeam']['server']['vbr_service_user']
   vbr_service_password node['veeam']['server']['vbr_service_password']
   vbr_service_port node['veeam']['server']['vbr_service_port']

--- a/resources/prerequisites.rb
+++ b/resources/prerequisites.rb
@@ -178,6 +178,7 @@ action_class do
       source ::File.join('sql_server', 'ConfigurationFile.ini.erb')
       provider Chef::Provider::File::Template
       variables(
+        sqlInstanceName: node['veeam']['server']['vbr_sqlserver_server'].split('\\')[-1],
         sqlSysAdminList: sql_sys_admin_list
       )
     end

--- a/templates/sql_server/ConfigurationFile.ini.erb
+++ b/templates/sql_server/ConfigurationFile.ini.erb
@@ -80,7 +80,7 @@ SQMREPORTING="False"
 
 ; Specify a default or named instance. MSSQLSERVER is the default instance for non-Express editions and SQLExpress for Express editions. This parameter is required when installing the SQL Server Database Engine (SQL), Analysis Services (AS), or Reporting Services (RS).
 
-INSTANCENAME="VeeamSQL2012"
+INSTANCENAME="<%= @sqlInstanceName %>"
 
 ; Agent account name
 


### PR DESCRIPTION
Hello Goodrum,

In this pull request I would like to propose we make the default SQL instance name flexible trough an attribute and change the default to "VeeamSQL2016". Currently the cookbook uses the instance name "VeeamSQL2012" for all installations. However according to the Veeam documentation "VeeamSQL2012" is only used for operating systems prior to Server 2008 R2 and Windows 7. Everything beyond that should use "VeeamSQL2016" which is the majority of users. 

Source: https://helpcenter.veeam.com/docs/backup/hyperv/install_vbr_sql.html?ver=100
Note: It seems what is stated in the documentation is true for manual installations. When performing an unattended installation however the default seems to fall back on "VeeamSQL2012" despite the OS. This is a bug in the Veeam installer. The proposed adjustments compensate for this bug.